### PR TITLE
Adds TCP queue mgmt options

### DIFF
--- a/templates/papertrail.conf.j2
+++ b/templates/papertrail.conf.j2
@@ -7,18 +7,19 @@ $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
 $ActionSendStreamDriverPermittedPeer *.papertrailapp.com
 
 {% if papertrail_enable_tcp %}
-$ActionResumeInterval 10
-$ActionQueueSize 100000
-$ActionQueueDiscardMark 97500
-$ActionQueueHighWaterMark 80000
-$ActionQueueType LinkedList
-$ActionQueueFileName papertrailqueue
-$ActionQueueCheckpointInterval 100
-$ActionQueueMaxDiskSpace 2g
-$ActionResumeRetryCount -1
-$ActionQueueSaveOnShutdown on
-$ActionQueueTimeoutEnqueue 10
-$ActionQueueDiscardSeverity 0
+$ActionResumeInterval {{ action_resume_interval }}
+$ActionQueueSize {{ action_queue_size }}
+$ActionQueueDiscardMark {{ action_queue_discard_mark }}
+$ActionQueueHighWaterMark {{ action_queue_high_water_mark }}
+$ActionQueueType {{ action_queue_type }}
+$ActionQueueFileName {{ action_queue_file_name }}
+$ActionQueueCheckpointInterval {{ action_queue_checkpoint_interval }}
+$ActionQueueMaxDiskSpace {{ action_queue_max_disk_space }}
+$ActionResumeRetryCount {{ action_resume_retry_count }}
+$ActionQueueSaveOnShutdown {{ action_queue_save_on_shutdown }}
+$ActionQueueTimeoutEnqueue {{ action_queue_timeout_enqueue }}
+$ActionQueueDiscardSeverity {{ action_queue_discard_severity }}
 {% endif %}
 
 {{ papertrail_loglevel }}                                         {{ '@@' if papertrail_enable_tcp else '@'}}{{ papertrail_destination }}
+

--- a/templates/papertrail.conf.j2
+++ b/templates/papertrail.conf.j2
@@ -5,4 +5,20 @@ $ActionSendStreamDriver gtls # use gtls netstream driver
 $ActionSendStreamDriverMode 1 # require TLS
 $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
 $ActionSendStreamDriverPermittedPeer *.papertrailapp.com
+
+{% if papertrail_enable_tcp %}
+$ActionResumeInterval 10
+$ActionQueueSize 100000
+$ActionQueueDiscardMark 97500
+$ActionQueueHighWaterMark 80000
+$ActionQueueType LinkedList
+$ActionQueueFileName papertrailqueue
+$ActionQueueCheckpointInterval 100
+$ActionQueueMaxDiskSpace 2g
+$ActionResumeRetryCount -1
+$ActionQueueSaveOnShutdown on
+$ActionQueueTimeoutEnqueue 10
+$ActionQueueDiscardSeverity 0
+{% endif %}
+
 {{ papertrail_loglevel }}                                         {{ '@@' if papertrail_enable_tcp else '@'}}{{ papertrail_destination }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,16 @@
 ---
 papertrail_service: "rsyslog"
+
+action_resume_interval: 10
+action_queue_size: 100000
+action_queue_discard_mark: 97500
+action_queue_high_water_mark: 80000
+action_queue_type: "LinkedList"
+action_queue_file_name: "papertrailqueue"
+action_queue_checkpoint_interval: 100
+action_queue_max_disk_space: 2g
+action_resume_retry_count: -1
+action_queue_save_on_shutdown: on
+action_queue_timeout_enqueue: 10
+action_queue_discard_severity: 0
+


### PR DESCRIPTION
Adds default queuing params when connecting to papertrail over TLS.

http://help.papertrailapp.com/kb/configuration/advanced-unix-logging-tips/#rsyslog_queue
