### PR TITLE
Allow setting different hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Role Variables
 - `papertrail_enable_tcp`: Enable TCP connection. Default: False
 - `papertrail_enable_tls:`: Enable TLS. Only works with TCP. Default: True
 - `papertrail_loglevel`: loglevel. Default: \*.\*
+- `papertrail_hostname`: Hostname to send logs from. Default: System hostname
 
 Rsyslog Defaults
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 papertrail_loglevel: "*.*"
 papertrail_enable_tcp: False
 papertrail_enable_tls: True
+# Set hostname to use instead of machine hostname
+papertrail_hostname: False
 
 # Rsyslog Defaults 
 papertrail_EscapeControlCharactersOnReceive: 'on'

--- a/templates/papertrail.conf.j2
+++ b/templates/papertrail.conf.j2
@@ -9,5 +9,8 @@ $ActionSendStreamDriverMode 1 # require TLS
 $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
 $ActionSendStreamDriverPermittedPeer *.papertrailapp.com
 {% endif %}
+{% if papertrail_hostname %}
+$LocalHostName {{ papertrail_hostname }}
+{% endif %}
 
 {{ papertrail_loglevel }}                                         {{ '@@' if papertrail_enable_tcp else '@'}}{{ papertrail_destination }}


### PR DESCRIPTION
Sometimes its helpful to be able to set different hostname that papertrail will register sent logs.